### PR TITLE
gccgo compile fix and support for perfstat_cpu_util

### DIFF
--- a/cpustat.go
+++ b/cpustat.go
@@ -20,6 +20,13 @@ import (
 	"unsafe"
 )
 
+var old_cpu_total_stat *C.perfstat_cpu_total_t
+
+func init() {
+	old_cpu_total_stat = (*C.perfstat_cpu_total_t)(C.malloc(C.sizeof_perfstat_cpu_total_t))
+	C.perfstat_cpu_total(nil, old_cpu_total_stat, C.sizeof_perfstat_cpu_total_t, 1)
+}
+
 func CpuStat() ([]CPU, error) {
 	var cpustat *C.perfstat_cpu_t
 	var cpu C.perfstat_id_t
@@ -96,3 +103,36 @@ func CpuUtilStat(intvl time.Duration) (*CPUUtil, error) {
 	u := perfstatcpuutil2cpuutil(cpuutil)
 	return &u, nil
 }
+
+func CpuUtilTotalStat() (*CPUUtil, error) {
+	var cpuutil *C.perfstat_cpu_util_t
+	var new_cpu_total_stat *C.perfstat_cpu_total_t
+	var data C.perfstat_rawdata_t
+
+	new_cpu_total_stat = (*C.perfstat_cpu_total_t)(C.malloc(C.sizeof_perfstat_cpu_total_t))
+	cpuutil = (*C.perfstat_cpu_util_t)(C.malloc(C.sizeof_perfstat_cpu_util_t))
+	defer C.free(unsafe.Pointer(cpuutil))
+
+	r := C.perfstat_cpu_total(nil, new_cpu_total_stat, C.sizeof_perfstat_cpu_total_t, 1)
+	if r <= 0 {
+		C.free(unsafe.Pointer(new_cpu_total_stat))
+		return nil, fmt.Errorf("error perfstat_cpu_total()")
+	}
+
+	data._type = C.UTIL_CPU_TOTAL
+	data.curstat = unsafe.Pointer(new_cpu_total_stat)
+	data.prevstat = unsafe.Pointer(old_cpu_total_stat)
+	data.sizeof_data = C.sizeof_perfstat_cpu_total_t
+	data.cur_elems = 1
+	data.prev_elems = 1
+
+	r = C.perfstat_cpu_util(&data, cpuutil, C.sizeof_perfstat_cpu_util_t, 1)
+	C.free(unsafe.Pointer(old_cpu_total_stat))
+	old_cpu_total_stat = new_cpu_total_stat
+	if r <= 0 {
+		return nil, fmt.Errorf("error perfstat_cpu_util()")
+	}
+	u := perfstatcpuutil2cpuutil(cpuutil)
+	return &u, nil
+}
+

--- a/helpers.go
+++ b/helpers.go
@@ -754,7 +754,7 @@ func fsinfo2filesystem(n *C.struct_fsinfo) FileSystem {
 	i.Device = C.GoString(n.devname)
 	i.MountPoint = C.GoString(n.fsname)
 	i.FSType = int(n.fstype)
-	i.Flags = int(n.flags)
+	i.Flags = uint(n.flags)
 	i.TotalBlocks = int64(n.totalblks)
 	i.FreeBlocks = int64(n.freeblks)
 	i.TotalInodes = int64(n.totalinodes)

--- a/types_fs.go
+++ b/types_fs.go
@@ -8,7 +8,7 @@ type FileSystem struct {
 	Device      string /* name of the mounted device */
 	MountPoint  string /* where the device is mounted */
 	FSType      int    /* File system type, see the constants below */
-	Flags       int    /* Flags of the file system */
+	Flags       uint   /* Flags of the file system */
 	TotalBlocks int64  /* number of 512 bytes blocks in the filesystem */
 	FreeBlocks  int64  /* number of free 512 bytes block in the filesystem */
 	TotalInodes int64  /* total number of inodes in the filesystem */


### PR DESCRIPTION
when compiling with gccgo - for cpus < power8 i've got an error:
vendor/github.com/power-devops/perfstat/types_fs.go:130:22: error: integer constant overflow
  130 |         case f.Flags&VFS_DIO != 0:

The other commit is a feature: To get the correct cpu usage of an lpar i had to call perfstat_cpu_util()
I implemented only the TotalStat, not the usage per cpu