### PR TITLE
fix(disk_adapter): stub missing fields for older AIX releases

### DIFF
--- a/c_helpers.c
+++ b/c_helpers.c
@@ -15,6 +15,29 @@ GETFUNC(process)
 GETFUNC(thread)
 GETFUNC(volumegroup)
 
+/* Older AIX releases ship CURR_VERSION_DISKADAPTER=2 and the struct ends at dk_wserv;
+ * these fields were added in version 3+.  The #if guards ensure the code compiles on
+ * both old and new releases, returning 0 for absent fields. */
+#if CURR_VERSION_DISKADAPTER >= 3
+#define GET_DA_FIELD(field) \
+u_longlong_t get_da_##field(perfstat_diskadapter_t *d) { return d->field; }
+#else
+#define GET_DA_FIELD(field) \
+u_longlong_t get_da_##field(perfstat_diskadapter_t *d) { (void)d; return 0; }
+#endif
+
+GET_DA_FIELD(min_rserv)
+GET_DA_FIELD(max_rserv)
+GET_DA_FIELD(min_wserv)
+GET_DA_FIELD(max_wserv)
+GET_DA_FIELD(wq_depth)
+GET_DA_FIELD(wq_sampled)
+GET_DA_FIELD(wq_time)
+GET_DA_FIELD(wq_min_time)
+GET_DA_FIELD(wq_max_time)
+GET_DA_FIELD(q_full)
+GET_DA_FIELD(q_sampled)
+
 double get_partition_mhz(perfstat_partition_config_t pinfo) {
 	return pinfo.processorMHz;
 }

--- a/c_helpers.h
+++ b/c_helpers.h
@@ -44,6 +44,21 @@ struct fsinfo {
         unsigned long freeinodes;
 };
 
+/* Conditional getters for perfstat_diskadapter_t fields added in
+ * CURR_VERSION_DISKADAPTER >= 3 (absent on older AIX releases where the macro is 2).
+ * Return 0 on older AIX releases. */
+extern u_longlong_t get_da_min_rserv(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_max_rserv(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_min_wserv(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_max_wserv(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_wq_depth(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_wq_sampled(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_wq_time(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_wq_min_time(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_wq_max_time(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_q_full(perfstat_diskadapter_t *);
+extern u_longlong_t get_da_q_sampled(perfstat_diskadapter_t *);
+
 extern double get_partition_mhz(perfstat_partition_config_t);
 extern char *get_ps_hostname(perfstat_pagingspace_t *);
 extern char *get_ps_filename(perfstat_pagingspace_t *);

--- a/helpers.go
+++ b/helpers.go
@@ -255,17 +255,19 @@ func perfstatdiskadapter2diskadapter(n *C.perfstat_diskadapter_t) DiskAdapter {
 	d.DkBSize = int64(n.dk_bsize)
 	d.DkRserv = int64(n.dk_rserv)
 	d.DkWserv = int64(n.dk_wserv)
-	d.MinRserv = int64(n.min_rserv)
-	d.MaxRserv = int64(n.max_rserv)
-	d.MinWserv = int64(n.min_wserv)
-	d.MaxWserv = int64(n.max_wserv)
-	d.WqDepth = int64(n.wq_depth)
-	d.WqSampled = int64(n.wq_sampled)
-	d.WqTime = int64(n.wq_time)
-	d.WqMinTime = int64(n.wq_min_time)
-	d.WqMaxTime = int64(n.wq_max_time)
-	d.QFull = int64(n.q_full)
-	d.QSampled = int64(n.q_sampled)
+	// Fields below were added in CURR_VERSION_DISKADAPTER >= 3; absent on older AIX
+	// releases (version 2). The wrapper returns 0 when the field is not present in the struct.
+	d.MinRserv = int64(C.get_da_min_rserv(n))
+	d.MaxRserv = int64(C.get_da_max_rserv(n))
+	d.MinWserv = int64(C.get_da_min_wserv(n))
+	d.MaxWserv = int64(C.get_da_max_wserv(n))
+	d.WqDepth = int64(C.get_da_wq_depth(n))
+	d.WqSampled = int64(C.get_da_wq_sampled(n))
+	d.WqTime = int64(C.get_da_wq_time(n))
+	d.WqMinTime = int64(C.get_da_wq_min_time(n))
+	d.WqMaxTime = int64(C.get_da_wq_max_time(n))
+	d.QFull = int64(C.get_da_q_full(n))
+	d.QSampled = int64(C.get_da_q_sampled(n))
 
 	return d
 }


### PR DESCRIPTION
# Description

Adds compatibility with older AIX releases (7.2 TL2 for instance) where the disk adapter structure is missing some fields introduced in newer versions. This prevented the build on these releases.

Stubs are used for unavailable fields, they all return zero.

# Additional notes

The issue #2 mentions this exact same error but on AIX 7.2 TL1. 